### PR TITLE
Updated address field to match new formatting

### DIFF
--- a/app/components/EditableAddress/EditableAddress.html
+++ b/app/components/EditableAddress/EditableAddress.html
@@ -2,5 +2,5 @@
     <input type="text" ng-model="data.streets" ng-change="onChange()" class="wirelessCoffeEditableInput">
 </span>
 <span ng-show="!editing">
-    {{data.street||data.streets}}, {{data.city}}, {{data.state}}
+    {{data.street||data.streets}}
 </span>


### PR DESCRIPTION
The location object has the street field that contains the entire address, so we no longer need the city or state.